### PR TITLE
Update mirror component to work with A-Frame 1.3

### DIFF
--- a/dist/aframe-mirror-component.js
+++ b/dist/aframe-mirror-component.js
@@ -73,8 +73,8 @@
 	   */
 	  init: function(){
 	          this.counter = this.data.interval;
-
-	          this.cam = new THREE.CubeCamera( 0.5, this.data.distance, this.data.resolution);
+		  const cubeRenderTarget = new THREE.WebGLCubeRenderTarget( this.data.resolution, { format: THREE.RGBFormat, generateMipmaps: true, minFilter: THREE.LinearMipmapLinearFilter } );
+	          this.cam = new THREE.CubeCamera( 0.5, this.data.distance, cubeRenderTarget);
 	          this.el.object3D.add( this.cam );
 	          this.mirrorMaterial = new THREE.MeshBasicMaterial( { color: this.data.color, refractionRatio: this.data.refraction, envMap: this.cam.renderTarget.texture } );
 	          this.done = false;


### PR DESCRIPTION
There's still a setFromMatrixPosition error that needs to be fixed before merging, hence the draft.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'setFromMatrixPosition')
    at Group.getWorldPosition (three.js:5961:1)
    at i.tick (aframe-mirror-component.js:100:84)
    at HTMLElement.value (a-scene.js:739:34)
    at HTMLElement.value (a-scene.js:789:36)
    at bind.js:12:17
    at onAnimationFrame (three.js:20001:1)
    at onAnimationFrame (three.js:9460:1)
```